### PR TITLE
Update breakpoints

### DIFF
--- a/builds/tokens/kda-design-system.raw.tokens.json
+++ b/builds/tokens/kda-design-system.raw.tokens.json
@@ -12,7 +12,7 @@
         },
         "sm": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n2.$value}"
+          "$value": 4
         },
         "md": {
           "$type": "number",
@@ -20,15 +20,15 @@
         },
         "lg": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n3.$value}"
+          "$value": 8
         },
         "xl": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n4.$value}"
+          "$value": 16
         },
         "xxl": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n6.$value}"
+          "$value": 24
         },
         "round": {
           "$type": "dimension",
@@ -39,27 +39,27 @@
         "$description": "Breakpoint sizes for viewports",
         "xs": {
           "$type": "dimension",
-          "$value": 640
+          "$value": "0rem"
         },
         "sm": {
           "$type": "dimension",
-          "$value": 768
+          "$value": "40rem"
         },
         "md": {
           "$type": "dimension",
-          "$value": 1024
+          "$value": "48rem"
         },
         "lg": {
           "$type": "dimension",
-          "$value": 1280
+          "$value": "64rem"
         },
         "xl": {
           "$type": "dimension",
-          "$value": 1536
+          "$value": "80rem"
         },
         "xxl": {
           "$type": "dimension",
-          "$value": 1980
+          "$value": "96rem"
         }
       },
       "color": {

--- a/builds/tokens/kda-design-system.tokens.json
+++ b/builds/tokens/kda-design-system.tokens.json
@@ -107,27 +107,27 @@
         "$description": "Breakpoint sizes for viewports",
         "xs": {
           "$type": "dimension",
-          "$value": 640
+          "$value": "0rem"
         },
         "sm": {
           "$type": "dimension",
-          "$value": 768
+          "$value": "40rem"
         },
         "md": {
           "$type": "dimension",
-          "$value": 1024
+          "$value": "48rem"
         },
         "lg": {
           "$type": "dimension",
-          "$value": 1280
+          "$value": "64rem"
         },
         "xl": {
           "$type": "dimension",
-          "$value": 1536
+          "$value": "80rem"
         },
         "xxl": {
           "$type": "dimension",
-          "$value": 1980
+          "$value": "96rem"
         }
       },
       "color": {
@@ -4744,7 +4744,7 @@
         },
         "sm": {
           "$type": "number",
-          "$value": "0.25rem"
+          "$value": 4
         },
         "md": {
           "$type": "number",
@@ -4752,15 +4752,15 @@
         },
         "lg": {
           "$type": "number",
-          "$value": "0.5rem"
+          "$value": 8
         },
         "xl": {
           "$type": "number",
-          "$value": "1rem"
+          "$value": 16
         },
         "xxl": {
           "$type": "number",
-          "$value": "1.5rem"
+          "$value": 24
         },
         "round": {
           "$type": "dimension",

--- a/tokens/breakpoint.tokens.json
+++ b/tokens/breakpoint.tokens.json
@@ -5,27 +5,27 @@
         "$description": "Breakpoint sizes for viewports",
         "xs": {
           "$type": "dimension",
-          "$value": 640
+          "$value": "0rem"
         },
         "sm": {
           "$type": "dimension",
-          "$value": 768
+          "$value": "40rem"
         },
         "md": {
           "$type": "dimension",
-          "$value": 1024
+          "$value": "48rem"
         },
         "lg": {
           "$type": "dimension",
-          "$value": 1280
+          "$value": "64rem"
         },
         "xl": {
           "$type": "dimension",
-          "$value": 1536
+          "$value": "80rem"
         },
         "xxl": {
           "$type": "dimension",
-          "$value": 1980
+          "$value": "96rem"
         }
       }
     }

--- a/tokens/radius.tokens.json
+++ b/tokens/radius.tokens.json
@@ -12,7 +12,7 @@
         },
         "sm": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n2.$value}"
+          "$value": 4
         },
         "md": {
           "$type": "number",
@@ -20,15 +20,15 @@
         },
         "lg": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n3.$value}"
+          "$value": 8
         },
         "xl": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n4.$value}"
+          "$value": 16
         },
         "xxl": {
           "$type": "number",
-          "$value": "{kda.foundation.size.n6.$value}"
+          "$value": 24
         },
         "round": {
           "$type": "dimension",


### PR DESCRIPTION
Currently the values listed for the breakpoints are all the maxWidth rather than the minWidth which means all of our breakpoint styling is off by one size. This PR updates the values to be the minWidth and uses rems which aligns with our existing breakpoints used in all applications consuming react-ui

Also updated the radii to always use a number rather than rem since we wouldn't want the radii behavior to differ depending on which size you use